### PR TITLE
Bugfix: Robust satellite name handling, error-proofing, and updated CLI/README for new usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,23 +11,21 @@ TurboVault4dbt_cli is an open-source CLI tool that automatically generates dbt m
 
 ## Prerequisites
 - Python 3.8+
-- Metadata analysis done and stored in a supported format (see below)
+- Metadata prepared in one of the supported formats (see below)
 - [dbt project](https://docs.getdbt.com/docs/get-started/getting-started-dbt-core)
 - [datavault4dbt](https://github.com/ScalefreeCOM/datavault4dbt) dbt package
 
----
-
-## Supported Metadata Sources
-- **Snowflake**
-- **BigQuery**
-- **Google Sheets**
-- **Excel**
-- **SQLite DB Files**
 
 ---
 
-## How does my metadata needs to look like?
-Your metadata needs to be stored in the following tables/worksheets: 
+## Supported Metadata Formats  
+- **Excel files:** `.xls`, `.xlsx`
+- **CSV files:** folder of CSVs (one per sheet/table)
+
+---
+
+## How does my metadata need to look like?
+Your metadata needs to be stored in the following tables/worksheets/files: 
 - [Source Data](https://github.com/ScalefreeCOM/turbovault4dbt/wiki/source-data)
 - [Standard Hubs](https://github.com/ScalefreeCOM/turbovault4dbt/wiki/hubs)
 - [Standard Links](https://github.com/ScalefreeCOM/turbovault4dbt/wiki/links)
@@ -37,55 +35,58 @@ Your metadata needs to be stored in the following tables/worksheets:
 - [Multi-Active Satellites](https://github.com/ScalefreeCOM/turbovault4dbt/wiki/multiactive-satellites)
 - [Point-In-Time Tables](https://github.com/ScalefreeCOM/turbovault4dbt/wiki/Point-In-Time)
 - [Reference Tables](https://github.com/ScalefreeCOM/turbovault4dbt/wiki/reference-tables)
----
-
-## Installation (CLI Version)
-
-1. Clone this repository:
-   ```sh
-   git clone https://github.com/ScalefreeCOM/turbovault4dbt.git
-   cd turbovault4dbt
-   ```
-2. (Recommended) Create and activate a virtual environment:
-   ```sh
-   python3 -m venv turbovault-env
-   source turbovault-env/bin/activate
-   ```
-3. Install in editable mode:
-   ```sh
-   pip install -e .
-   ```
 
 ---
 
+## Installation
+
+You can install TurboVault4dbt_cli directly from PyPI:
+```sh
+pip install turbovault4dbt
+```
+Or install from source for development:
+```sh
+git clone https://github.com/ScalefreeCOM/turbovault4dbt.git
+cd turbovault4dbt
+pip install -e .
+```
 ## Quickstart: Using the CLI
 
 ### 1. Prepare your metadata
-- See [metadata_ddl/](metadata_ddl/) for DDL scripts and Excel templates.
-- Configure your metadata connection in `src/turbovault4dbt/backend/config/config.ini`.
+- Prepare your metadata as Excel (`.xls` or `.xlsx`) or as a folder of CSV files (one CSV per sheet/table, filenames matching required sheets).
+- (See [metadata_ddl/](metadata_ddl/) for example templates.)
 
 ### 2. Run TurboVault4dbt_cli
 
 #### Basic usage:
 ```sh
-# List available nodes from your metadata Excel file
-$ turbovault list --file path/to/your.xlsx
+# List all nodes in your metadata (Excel or CSV)
+turbovault list -f xlsx path/to/your.xlsx
+turbovault list -f csv path/to/your_csv_folder
+
+# Generate dbt models for all nodes
+turbovault run -f xlsx path/to/your.xlsx
+turbovault run -f csv path/to/your_csv_folder
 
 # Generate dbt models for selected nodes
-$ turbovault run --file path/to/your.xlsx -s hub1
-
-# Use selectors (e.g., +node, node+, @node)
-$ turbovault run --file path/to/your.xlsx -s '+sat1 hub2+ @masat3'
+turbovault run -f xlsx path/to/your.xlsx -s hub1 link1 sat1
+turbovault run -f csv path/to/your_csv_folder -s '+hub1' '@sat1'
 
 # Specify output directory
-$ turbovault run --file path/to/your.xlsx --output-dir my_output_dir -s hub1
+turbovault run -f xlsx path/to/your.xlsx --output-dir my_output_dir
 ```
-
 #### Command reference:
-- `turbovault run --file <input.xlsx> [-s <selector>] [--output-dir <dir>]`  
-  Generate dbt models for selected nodes.
-- `turbovault list --file <input.xlsx> [-s <selector>]`  
+- `turbovault run -f {xls|xlsx|csv} <input> [-s <selectors>] [--output-dir <dir>]`  
+  Generate dbt models for all or selected nodes.
+- `turbovault list -f {xls|xlsx|csv} <input> [-s <selectors>]`  
   List resolved nodes for a selector (dry run).
+
+#### Arguments:
+- `-f, --format`: Input format. Must be one of: `xls`, `xlsx`, `csv`
+- `input`: Path to Excel file (`.xls`/`.xlsx`) or folder containing CSV files (for `csv`)
+- `-s, --select`: (Optional) Node selectors (space-separated).  
+   Examples: `hub1`, `+sat1`, `hub2+`, `@masat3`
+- `--output-dir`: (Optional) Output directory for generated files
 
 #### Selector syntax:
 - `A+` — node A and all descendants

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "turbovault4dbt"
-version = "0.2.4"
+version = "0.2.5"
 description = "CLI for Turbovault 4 DBT"
 authors = [
     { name = "Pawel", email = "pawel.sala01@wp.pl" }

--- a/src/turbovault4dbt/backend/procs/sqlite3/ma_satellite.py
+++ b/src/turbovault4dbt/backend/procs/sqlite3/ma_satellite.py
@@ -76,8 +76,15 @@ def generate_ma_satellite(data_structure):
             
   
         satellite_model_name_splitted_list = satellite_name.split('_')
-        satellite_model_name_splitted_list[-2] += '0'
-        satellite_model_name_v0 = '_'.join(satellite_model_name_splitted_list)
+        if len(satellite_model_name_splitted_list) >= 2:
+            satellite_model_name_splitted_list[-2] += '0'
+            satellite_model_name_v0 = '_'.join(satellite_model_name_splitted_list)
+        else:
+            satellite_model_name_v0 = satellite_name + '0'
+            data_structure['print2FeedbackConsole'](
+                message=f"Satellite name '{satellite_name}' does not have enough '_' segments, used fallback name '{satellite_model_name_v0}'"
+            )
+
 
         filename = os.path.join(model_path_v0 , f"{satellite_model_name_v0}.sql")
                 

--- a/src/turbovault4dbt/backend/procs/sqlite3/satellite.py
+++ b/src/turbovault4dbt/backend/procs/sqlite3/satellite.py
@@ -73,8 +73,15 @@ def generate_satellite(data_structure):
             
   
         satellite_model_name_splitted_list = satellite_name.split('_')
-        satellite_model_name_splitted_list[-2] += '0'
-        satellite_model_name_v0 = '_'.join(satellite_model_name_splitted_list)
+        if len(satellite_model_name_splitted_list) >= 2:
+            satellite_model_name_splitted_list[-2] += '0'
+            satellite_model_name_v0 = '_'.join(satellite_model_name_splitted_list)
+        else:
+            satellite_model_name_v0 = satellite_name + '0'
+            data_structure['print2FeedbackConsole'](
+                message=f"Satellite name '{satellite_name}' does not have enough '_' segments, used fallback name '{satellite_model_name_v0}'"
+            )
+
 
         filename = os.path.join(model_path_v0 , f"{satellite_model_name_v0}.sql")
                 

--- a/src/turbovault4dbt/main.py
+++ b/src/turbovault4dbt/main.py
@@ -92,11 +92,14 @@ def main():
 
         tasks = set()
         sources_to_process = []
+        valid_types_for_source_data = ['hub', 'satellite', 'link', 'ma_satellite', 'nh_satellite']
+
         for node in selected_nodes:
             ntype = G.nodes[node].get('type')
             if ntype in type_to_task:
                 tasks.add(type_to_task[ntype])
-                sources_to_process.append(node)
+                if ntype in valid_types_for_source_data and '_hub' not in node:
+                    sources_to_process.append(node)
 
         if not sources_to_process:
             print("No valid sources/entities selected for code generation.")

--- a/tests/case_01/expected_output/masat1.sql
+++ b/tests/case_01/expected_output/masat1.sql
@@ -1,0 +1,23 @@
+{{ config(schema='rdv', materialized='view') }} 
+
+{%- set yaml_metadata -%}
+sat_v0: 'masat10'
+hashkey: 'hpk_hub1'
+hashdiff: 'hd_masat1' 
+ma_attribute: 
+  - multiattr_masat1
+  - multiattr2_masat1
+
+ledts_alias: 'valid_to'
+add_is_current_flag: true
+{%- endset -%}    
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+
+{{ datavault4dbt.ma_sat_v1(sat_v0=metadata_dict.get("sat_v0"),
+                        hashkey=metadata_dict.get("hashkey"),
+                        hashdiff=metadata_dict.get("hashdiff"),
+                        ma_attribute=metadata_dict.get("ma_attribute"),
+                        ledts_alias=metadata_dict.get("ledts_alias"),
+                        add_is_current_flag=metadata_dict.get("add_is_current_flag")) }}

--- a/tests/case_01/expected_output/masat10.sql
+++ b/tests/case_01/expected_output/masat10.sql
@@ -1,0 +1,23 @@
+{{ config(schema='rdv',
+           materialized='incremental') }} 
+
+{%- set yaml_metadata -%}
+source_model: "stg_masat1" 
+parent_hashkey: "hpk_hub1"
+src_hashdiff: "hd_masat1"
+src_ma_key: 
+  - multiattr_masat1
+  - multiattr2_masat1
+
+src_payload: 
+  - target_col_masat1
+
+{%- endset -%}
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+{{ datavault4dbt.ma_sat_v0(source_model=metadata_dict.get('source_model'),
+                        parent_hashkey=metadata_dict.get('parent_hashkey'),
+                        src_hashdiff=metadata_dict.get('src_hashdiff'),
+                        src_ma_key=metadata_dict.get('src_ma_key'),
+                        src_payload=metadata_dict.get('src_payload')) }}

--- a/tests/case_01/expected_output/masat2.sql
+++ b/tests/case_01/expected_output/masat2.sql
@@ -1,0 +1,23 @@
+{{ config(schema='rdv', materialized='view') }} 
+
+{%- set yaml_metadata -%}
+sat_v0: 'masat20'
+hashkey: 'hpk_hub2'
+hashdiff: 'hd_masat2' 
+ma_attribute: 
+  - multiattr_masat2
+  - multiattr2_masat2
+
+ledts_alias: 'valid_to'
+add_is_current_flag: true
+{%- endset -%}    
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+
+{{ datavault4dbt.ma_sat_v1(sat_v0=metadata_dict.get("sat_v0"),
+                        hashkey=metadata_dict.get("hashkey"),
+                        hashdiff=metadata_dict.get("hashdiff"),
+                        ma_attribute=metadata_dict.get("ma_attribute"),
+                        ledts_alias=metadata_dict.get("ledts_alias"),
+                        add_is_current_flag=metadata_dict.get("add_is_current_flag")) }}

--- a/tests/case_01/expected_output/masat20.sql
+++ b/tests/case_01/expected_output/masat20.sql
@@ -1,0 +1,23 @@
+{{ config(schema='rdv',
+           materialized='incremental') }} 
+
+{%- set yaml_metadata -%}
+source_model: "stg_masat2" 
+parent_hashkey: "hpk_hub2"
+src_hashdiff: "hd_masat2"
+src_ma_key: 
+  - multiattr_masat2
+  - multiattr2_masat2
+
+src_payload: 
+  - target_col_masat2
+
+{%- endset -%}
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+{{ datavault4dbt.ma_sat_v0(source_model=metadata_dict.get('source_model'),
+                        parent_hashkey=metadata_dict.get('parent_hashkey'),
+                        src_hashdiff=metadata_dict.get('src_hashdiff'),
+                        src_ma_key=metadata_dict.get('src_ma_key'),
+                        src_payload=metadata_dict.get('src_payload')) }}

--- a/tests/case_01/expected_output/masat3.sql
+++ b/tests/case_01/expected_output/masat3.sql
@@ -1,0 +1,23 @@
+{{ config(schema='rdv', materialized='view') }} 
+
+{%- set yaml_metadata -%}
+sat_v0: 'masat30'
+hashkey: 'hpk_hub3'
+hashdiff: 'hd_masat3' 
+ma_attribute: 
+  - multiattr_masat3
+  - multiattr2_masat3
+
+ledts_alias: 'valid_to'
+add_is_current_flag: true
+{%- endset -%}    
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+
+{{ datavault4dbt.ma_sat_v1(sat_v0=metadata_dict.get("sat_v0"),
+                        hashkey=metadata_dict.get("hashkey"),
+                        hashdiff=metadata_dict.get("hashdiff"),
+                        ma_attribute=metadata_dict.get("ma_attribute"),
+                        ledts_alias=metadata_dict.get("ledts_alias"),
+                        add_is_current_flag=metadata_dict.get("add_is_current_flag")) }}

--- a/tests/case_01/expected_output/masat30.sql
+++ b/tests/case_01/expected_output/masat30.sql
@@ -1,0 +1,23 @@
+{{ config(schema='rdv',
+           materialized='incremental') }} 
+
+{%- set yaml_metadata -%}
+source_model: "stg_masat3" 
+parent_hashkey: "hpk_hub3"
+src_hashdiff: "hd_masat3"
+src_ma_key: 
+  - multiattr_masat3
+  - multiattr2_masat3
+
+src_payload: 
+  - target_col_masat3
+
+{%- endset -%}
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+{{ datavault4dbt.ma_sat_v0(source_model=metadata_dict.get('source_model'),
+                        parent_hashkey=metadata_dict.get('parent_hashkey'),
+                        src_hashdiff=metadata_dict.get('src_hashdiff'),
+                        src_ma_key=metadata_dict.get('src_ma_key'),
+                        src_payload=metadata_dict.get('src_payload')) }}

--- a/tests/case_01/expected_output/masat4.sql
+++ b/tests/case_01/expected_output/masat4.sql
@@ -1,0 +1,23 @@
+{{ config(schema='rdv', materialized='view') }} 
+
+{%- set yaml_metadata -%}
+sat_v0: 'masat40'
+hashkey: 'hpk_hub4'
+hashdiff: 'hd_masat4' 
+ma_attribute: 
+  - multiattr_masat4
+  - multiattr2_masat4
+
+ledts_alias: 'valid_to'
+add_is_current_flag: true
+{%- endset -%}    
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+
+{{ datavault4dbt.ma_sat_v1(sat_v0=metadata_dict.get("sat_v0"),
+                        hashkey=metadata_dict.get("hashkey"),
+                        hashdiff=metadata_dict.get("hashdiff"),
+                        ma_attribute=metadata_dict.get("ma_attribute"),
+                        ledts_alias=metadata_dict.get("ledts_alias"),
+                        add_is_current_flag=metadata_dict.get("add_is_current_flag")) }}

--- a/tests/case_01/expected_output/masat40.sql
+++ b/tests/case_01/expected_output/masat40.sql
@@ -1,0 +1,23 @@
+{{ config(schema='rdv',
+           materialized='incremental') }} 
+
+{%- set yaml_metadata -%}
+source_model: "stg_masat4" 
+parent_hashkey: "hpk_hub4"
+src_hashdiff: "hd_masat4"
+src_ma_key: 
+  - multiattr_masat4
+  - multiattr2_masat4
+
+src_payload: 
+  - target_col_masat4
+
+{%- endset -%}
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+{{ datavault4dbt.ma_sat_v0(source_model=metadata_dict.get('source_model'),
+                        parent_hashkey=metadata_dict.get('parent_hashkey'),
+                        src_hashdiff=metadata_dict.get('src_hashdiff'),
+                        src_ma_key=metadata_dict.get('src_ma_key'),
+                        src_payload=metadata_dict.get('src_payload')) }}

--- a/tests/case_01/expected_output/sat1.sql
+++ b/tests/case_01/expected_output/sat1.sql
@@ -1,0 +1,16 @@
+{{ config(schema='rdv',
+           materialized='view') }} 
+
+{%- set yaml_metadata -%}
+sat_v0: 'sat10'
+hashkey: "hpk_hub1"
+hashdiff: 'hd_sat1'
+{%- endset -%}
+
+{% set metadata_dict = fromyaml(yaml_metadata) %}
+
+{{ datavault4dbt.sat_v1(sat_v0=metadata_dict.get('sat_v0'),
+    hashkey=metadata_dict.get('hashkey'),
+    hashdiff=metadata_dict.get('hashdiff'),
+    ledts_alias=metadata_dict.get('ledts_alias'),
+    add_is_current_flag=true) }}

--- a/tests/case_01/expected_output/sat10.sql
+++ b/tests/case_01/expected_output/sat10.sql
@@ -1,0 +1,19 @@
+{{ config(schema='rdv',
+           materialized='incremental',
+           unique_key=['hpk_hub1', 'ldts']) }} 
+
+{%- set yaml_metadata -%}
+source_model: "stg_sat1" 
+parent_hashkey: "hpk_hub1"
+src_hashdiff: 'hd_sat1'
+src_payload: 
+  - target_col_sat1
+
+{%- endset -%}    
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+{{ datavault4dbt.sat_v0(parent_hashkey=metadata_dict.get('parent_hashkey'),
+                        src_hashdiff=metadata_dict.get('src_hashdiff'),
+                        source_model=metadata_dict.get('source_model'),
+                        src_payload=metadata_dict.get('src_payload')) }}

--- a/tests/case_01/expected_output/sat2.sql
+++ b/tests/case_01/expected_output/sat2.sql
@@ -1,0 +1,16 @@
+{{ config(schema='rdv',
+           materialized='view') }} 
+
+{%- set yaml_metadata -%}
+sat_v0: 'sat20'
+hashkey: "hpk_hub2"
+hashdiff: 'hd_sat2'
+{%- endset -%}
+
+{% set metadata_dict = fromyaml(yaml_metadata) %}
+
+{{ datavault4dbt.sat_v1(sat_v0=metadata_dict.get('sat_v0'),
+    hashkey=metadata_dict.get('hashkey'),
+    hashdiff=metadata_dict.get('hashdiff'),
+    ledts_alias=metadata_dict.get('ledts_alias'),
+    add_is_current_flag=true) }}

--- a/tests/case_01/expected_output/sat20.sql
+++ b/tests/case_01/expected_output/sat20.sql
@@ -1,0 +1,19 @@
+{{ config(schema='rdv',
+           materialized='incremental',
+           unique_key=['hpk_hub2', 'ldts']) }} 
+
+{%- set yaml_metadata -%}
+source_model: "stg_sat2" 
+parent_hashkey: "hpk_hub2"
+src_hashdiff: 'hd_sat2'
+src_payload: 
+  - target_col_sat2
+
+{%- endset -%}    
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+{{ datavault4dbt.sat_v0(parent_hashkey=metadata_dict.get('parent_hashkey'),
+                        src_hashdiff=metadata_dict.get('src_hashdiff'),
+                        source_model=metadata_dict.get('source_model'),
+                        src_payload=metadata_dict.get('src_payload')) }}

--- a/tests/case_01/expected_output/sat3.sql
+++ b/tests/case_01/expected_output/sat3.sql
@@ -1,0 +1,16 @@
+{{ config(schema='rdv',
+           materialized='view') }} 
+
+{%- set yaml_metadata -%}
+sat_v0: 'sat30'
+hashkey: "hpk_hub3"
+hashdiff: 'hd_sat3'
+{%- endset -%}
+
+{% set metadata_dict = fromyaml(yaml_metadata) %}
+
+{{ datavault4dbt.sat_v1(sat_v0=metadata_dict.get('sat_v0'),
+    hashkey=metadata_dict.get('hashkey'),
+    hashdiff=metadata_dict.get('hashdiff'),
+    ledts_alias=metadata_dict.get('ledts_alias'),
+    add_is_current_flag=true) }}

--- a/tests/case_01/expected_output/sat30.sql
+++ b/tests/case_01/expected_output/sat30.sql
@@ -1,0 +1,19 @@
+{{ config(schema='rdv',
+           materialized='incremental',
+           unique_key=['hpk_hub3', 'ldts']) }} 
+
+{%- set yaml_metadata -%}
+source_model: "stg_sat3" 
+parent_hashkey: "hpk_hub3"
+src_hashdiff: 'hd_sat3'
+src_payload: 
+  - target_col_sat3
+
+{%- endset -%}    
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+{{ datavault4dbt.sat_v0(parent_hashkey=metadata_dict.get('parent_hashkey'),
+                        src_hashdiff=metadata_dict.get('src_hashdiff'),
+                        source_model=metadata_dict.get('source_model'),
+                        src_payload=metadata_dict.get('src_payload')) }}

--- a/tests/case_01/expected_output/sat4.sql
+++ b/tests/case_01/expected_output/sat4.sql
@@ -1,0 +1,16 @@
+{{ config(schema='rdv',
+           materialized='view') }} 
+
+{%- set yaml_metadata -%}
+sat_v0: 'sat40'
+hashkey: "hpk_hub4"
+hashdiff: 'hd_sat4'
+{%- endset -%}
+
+{% set metadata_dict = fromyaml(yaml_metadata) %}
+
+{{ datavault4dbt.sat_v1(sat_v0=metadata_dict.get('sat_v0'),
+    hashkey=metadata_dict.get('hashkey'),
+    hashdiff=metadata_dict.get('hashdiff'),
+    ledts_alias=metadata_dict.get('ledts_alias'),
+    add_is_current_flag=true) }}

--- a/tests/case_01/expected_output/sat40.sql
+++ b/tests/case_01/expected_output/sat40.sql
@@ -1,0 +1,19 @@
+{{ config(schema='rdv',
+           materialized='incremental',
+           unique_key=['hpk_hub4', 'ldts']) }} 
+
+{%- set yaml_metadata -%}
+source_model: "stg_sat4" 
+parent_hashkey: "hpk_hub4"
+src_hashdiff: 'hd_sat4'
+src_payload: 
+  - target_col_sat4
+
+{%- endset -%}    
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+{{ datavault4dbt.sat_v0(parent_hashkey=metadata_dict.get('parent_hashkey'),
+                        src_hashdiff=metadata_dict.get('src_hashdiff'),
+                        source_model=metadata_dict.get('source_model'),
+                        src_payload=metadata_dict.get('src_payload')) }}

--- a/tests/case_02/expected_output/masat2.sql
+++ b/tests/case_02/expected_output/masat2.sql
@@ -1,0 +1,23 @@
+{{ config(schema='rdv', materialized='view') }} 
+
+{%- set yaml_metadata -%}
+sat_v0: 'masat20'
+hashkey: 'hpk_hub2'
+hashdiff: 'hd_masat2' 
+ma_attribute: 
+  - multiattr_masat2
+  - multiattr2_masat2
+
+ledts_alias: 'valid_to'
+add_is_current_flag: true
+{%- endset -%}    
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+
+{{ datavault4dbt.ma_sat_v1(sat_v0=metadata_dict.get("sat_v0"),
+                        hashkey=metadata_dict.get("hashkey"),
+                        hashdiff=metadata_dict.get("hashdiff"),
+                        ma_attribute=metadata_dict.get("ma_attribute"),
+                        ledts_alias=metadata_dict.get("ledts_alias"),
+                        add_is_current_flag=metadata_dict.get("add_is_current_flag")) }}

--- a/tests/case_02/expected_output/masat20.sql
+++ b/tests/case_02/expected_output/masat20.sql
@@ -1,0 +1,23 @@
+{{ config(schema='rdv',
+           materialized='incremental') }} 
+
+{%- set yaml_metadata -%}
+source_model: "stg_masat2" 
+parent_hashkey: "hpk_hub2"
+src_hashdiff: "hd_masat2"
+src_ma_key: 
+  - multiattr_masat2
+  - multiattr2_masat2
+
+src_payload: 
+  - target_col_masat2
+
+{%- endset -%}
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+{{ datavault4dbt.ma_sat_v0(source_model=metadata_dict.get('source_model'),
+                        parent_hashkey=metadata_dict.get('parent_hashkey'),
+                        src_hashdiff=metadata_dict.get('src_hashdiff'),
+                        src_ma_key=metadata_dict.get('src_ma_key'),
+                        src_payload=metadata_dict.get('src_payload')) }}

--- a/tests/case_02/expected_output/masat3.sql
+++ b/tests/case_02/expected_output/masat3.sql
@@ -1,0 +1,23 @@
+{{ config(schema='rdv', materialized='view') }} 
+
+{%- set yaml_metadata -%}
+sat_v0: 'masat30'
+hashkey: 'hpk_hub3'
+hashdiff: 'hd_masat3' 
+ma_attribute: 
+  - multiattr_masat3
+  - multiattr2_masat3
+
+ledts_alias: 'valid_to'
+add_is_current_flag: true
+{%- endset -%}    
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+
+{{ datavault4dbt.ma_sat_v1(sat_v0=metadata_dict.get("sat_v0"),
+                        hashkey=metadata_dict.get("hashkey"),
+                        hashdiff=metadata_dict.get("hashdiff"),
+                        ma_attribute=metadata_dict.get("ma_attribute"),
+                        ledts_alias=metadata_dict.get("ledts_alias"),
+                        add_is_current_flag=metadata_dict.get("add_is_current_flag")) }}

--- a/tests/case_02/expected_output/masat30.sql
+++ b/tests/case_02/expected_output/masat30.sql
@@ -1,0 +1,23 @@
+{{ config(schema='rdv',
+           materialized='incremental') }} 
+
+{%- set yaml_metadata -%}
+source_model: "stg_masat3" 
+parent_hashkey: "hpk_hub3"
+src_hashdiff: "hd_masat3"
+src_ma_key: 
+  - multiattr_masat3
+  - multiattr2_masat3
+
+src_payload: 
+  - target_col_masat3
+
+{%- endset -%}
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+{{ datavault4dbt.ma_sat_v0(source_model=metadata_dict.get('source_model'),
+                        parent_hashkey=metadata_dict.get('parent_hashkey'),
+                        src_hashdiff=metadata_dict.get('src_hashdiff'),
+                        src_ma_key=metadata_dict.get('src_ma_key'),
+                        src_payload=metadata_dict.get('src_payload')) }}

--- a/tests/case_02/expected_output/sat1.sql
+++ b/tests/case_02/expected_output/sat1.sql
@@ -1,0 +1,16 @@
+{{ config(schema='rdv',
+           materialized='view') }} 
+
+{%- set yaml_metadata -%}
+sat_v0: 'sat10'
+hashkey: "hpk_hub1"
+hashdiff: 'hd_sat1'
+{%- endset -%}
+
+{% set metadata_dict = fromyaml(yaml_metadata) %}
+
+{{ datavault4dbt.sat_v1(sat_v0=metadata_dict.get('sat_v0'),
+    hashkey=metadata_dict.get('hashkey'),
+    hashdiff=metadata_dict.get('hashdiff'),
+    ledts_alias=metadata_dict.get('ledts_alias'),
+    add_is_current_flag=true) }}

--- a/tests/case_02/expected_output/sat10.sql
+++ b/tests/case_02/expected_output/sat10.sql
@@ -1,0 +1,19 @@
+{{ config(schema='rdv',
+           materialized='incremental',
+           unique_key=['hpk_hub1', 'ldts']) }} 
+
+{%- set yaml_metadata -%}
+source_model: "stg_sat1" 
+parent_hashkey: "hpk_hub1"
+src_hashdiff: 'hd_sat1'
+src_payload: 
+  - target_col_sat1
+
+{%- endset -%}    
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+{{ datavault4dbt.sat_v0(parent_hashkey=metadata_dict.get('parent_hashkey'),
+                        src_hashdiff=metadata_dict.get('src_hashdiff'),
+                        source_model=metadata_dict.get('source_model'),
+                        src_payload=metadata_dict.get('src_payload')) }}

--- a/tests/case_02/expected_output/sat2.sql
+++ b/tests/case_02/expected_output/sat2.sql
@@ -1,0 +1,16 @@
+{{ config(schema='rdv',
+           materialized='view') }} 
+
+{%- set yaml_metadata -%}
+sat_v0: 'sat20'
+hashkey: "hpk_hub2"
+hashdiff: 'hd_sat2'
+{%- endset -%}
+
+{% set metadata_dict = fromyaml(yaml_metadata) %}
+
+{{ datavault4dbt.sat_v1(sat_v0=metadata_dict.get('sat_v0'),
+    hashkey=metadata_dict.get('hashkey'),
+    hashdiff=metadata_dict.get('hashdiff'),
+    ledts_alias=metadata_dict.get('ledts_alias'),
+    add_is_current_flag=true) }}

--- a/tests/case_02/expected_output/sat20.sql
+++ b/tests/case_02/expected_output/sat20.sql
@@ -1,0 +1,19 @@
+{{ config(schema='rdv',
+           materialized='incremental',
+           unique_key=['hpk_hub2', 'ldts']) }} 
+
+{%- set yaml_metadata -%}
+source_model: "stg_sat2" 
+parent_hashkey: "hpk_hub2"
+src_hashdiff: 'hd_sat2'
+src_payload: 
+  - target_col_sat2
+
+{%- endset -%}    
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+{{ datavault4dbt.sat_v0(parent_hashkey=metadata_dict.get('parent_hashkey'),
+                        src_hashdiff=metadata_dict.get('src_hashdiff'),
+                        source_model=metadata_dict.get('source_model'),
+                        src_payload=metadata_dict.get('src_payload')) }}

--- a/tests/case_05/expected_output/sat1.sql
+++ b/tests/case_05/expected_output/sat1.sql
@@ -1,0 +1,16 @@
+{{ config(schema='rdv',
+           materialized='view') }} 
+
+{%- set yaml_metadata -%}
+sat_v0: 'sat10'
+hashkey: "hpk_hub1"
+hashdiff: 'hd_sat1'
+{%- endset -%}
+
+{% set metadata_dict = fromyaml(yaml_metadata) %}
+
+{{ datavault4dbt.sat_v1(sat_v0=metadata_dict.get('sat_v0'),
+    hashkey=metadata_dict.get('hashkey'),
+    hashdiff=metadata_dict.get('hashdiff'),
+    ledts_alias=metadata_dict.get('ledts_alias'),
+    add_is_current_flag=true) }}

--- a/tests/case_05/expected_output/sat10.sql
+++ b/tests/case_05/expected_output/sat10.sql
@@ -1,0 +1,19 @@
+{{ config(schema='rdv',
+           materialized='incremental',
+           unique_key=['hpk_hub1', 'ldts']) }} 
+
+{%- set yaml_metadata -%}
+source_model: "stg_sat1" 
+parent_hashkey: "hpk_hub1"
+src_hashdiff: 'hd_sat1'
+src_payload: 
+  - target_col_sat1
+
+{%- endset -%}    
+
+{%- set metadata_dict = fromyaml(yaml_metadata) -%}
+
+{{ datavault4dbt.sat_v0(parent_hashkey=metadata_dict.get('parent_hashkey'),
+                        src_hashdiff=metadata_dict.get('src_hashdiff'),
+                        source_model=metadata_dict.get('source_model'),
+                        src_payload=metadata_dict.get('src_payload')) }}


### PR DESCRIPTION
This PR addresses several critical issues and improvements:

- Fixes IndexError when generating satellite and masatellite model names that lack underscores (e.g., "sat3"). Now, names are handled robustly, with a fallback and a clear warning if the naming convention is not met.
- Updates CLI basic usage: 
    - Adds required `-f` flag for file format (`xls`, `xlsx`, or `csv`).
    - Shows support for Excel and CSV metadata input.
- Fully updates the README to reflect the new installation method (via pip), supported formats, and current command syntax and selector usage.
- General code and documentation cleanup for clarity and maintainability.
